### PR TITLE
fix typo in gerty extension typo

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -15,7 +15,7 @@
             "id": "gerty",
             "repo": "https://github.com/lnbits/gerty",
             "name": "Gerty",
-            "version": "0.2.1",
+            "version": "0.1.2",
             "short_description": "Your bitcoin assistant",
             "icon": "https://raw.githubusercontent.com/lnbits/gerty/main/static/gerty.png",
             "archive": "https://github.com/lnbits/lnbits-extensions/raw/main/extensions/gerty/gerty-extension-0.1.2.zip",


### PR DESCRIPTION
says `0.2.1` while it should say `0.1.2` (see archive URL and releases here: https://github.com/lnbits/gerty/releases)