### PR TITLE
Update Gerty extension to 0.1.4

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -15,11 +15,11 @@
             "id": "gerty",
             "repo": "https://github.com/lnbits/gerty",
             "name": "Gerty",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "short_description": "Your Bitcoin assistant",
             "icon": "https://raw.githubusercontent.com/lnbits/gerty/main/static/gerty.png",
-            "archive": "https://github.com/lnbits/gerty/archive/refs/tags/0.1.3.zip",
-            "hash": "556679188dd80b85c2c0825333b7d039b98f9eb982987d1bbd485a82926499e1"
+            "archive": "https://github.com/lnbits/gerty/archive/refs/tags/0.1.4.zip",
+            "hash": "d676c40ab1242fb1c21fed89b0af2df8c0fee96c9f75686bb23d4635b6bccac3"
         },
         {
             "id": "jukebox",


### PR DESCRIPTION
Timezone offset and UI fixes
----

This release adds a UTC timezone offset field. Useful if you are one of the 7,942,645,086 people living outside UTC 0.

Also, some nice UI fixes encountered when running multiple Gertys