### PR TITLE
chore: `nostrmarket` 0.2.8 version bump

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -375,11 +375,11 @@
             "id": "nostrmarket",
             "repo": "https://github.com/lnbits/nostrmarket",
             "name": "Nostr Market",
-            "version": "0.2.5",
+            "version": "0.2.8",
             "short_description": "Nostr merchant and market",
-            "icon": "https://raw.githubusercontent.com/lnbits/nostrmarket/v0.2.5/static/images/bitcoin-shop.png",
-            "archive": "https://github.com/lnbits/nostrmarket/archive/refs/tags/v0.2.5.zip",
-            "hash": "17384d6ae5ec21fdfbdb42dd803cc137293bde63ea789daf852c526ca086fafd"
+            "icon": "https://raw.githubusercontent.com/lnbits/nostrmarket/v0.2.8/static/images/bitcoin-shop.png",
+            "archive": "https://github.com/lnbits/nostrmarket/archive/refs/tags/v0.2.8.zip",
+            "hash": "5097ec1f5eec7283dc5077084a2382058bd957d02b6dac6dd1c86b84f6a7ecf6"
         }
     ]
 }


### PR DESCRIPTION
Release Notes: https://github.com/lnbits/nostrmarket/releases/tag/v0.2.8

https://user-images.githubusercontent.com/2951406/236182851-d86a1ebb-4876-4821-a72c-704650f490b4.mov

