### PR TITLE
fix: dont run check ci on main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,5 @@
 name: LNbits Extension CI
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
check currently fail on main, and i think are not necessary because `main` is protected and it will be checked on pull requests. by rebasing the pr's onto current main before merging the pr we can make sure main never fails