### PR TITLE
fix: remove lnaddress from install test

### DIFF
--- a/integration/001_extensions-enable-all.jmx
+++ b/integration/001_extensions-enable-all.jmx
@@ -30,7 +30,7 @@
           </elementProp>
           <elementProp name="excludedExtensions" elementType="Argument">
             <stringProp name="Argument.name">excludedExtensions</stringProp>
-            <stringProp name="Argument.value">discordbot</stringProp>
+            <stringProp name="Argument.value">discordbot,lnaddress</stringProp>
             <stringProp name="Argument.desc">Comma separated values, no spaces.</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>


### PR DESCRIPTION
Prepare for: https://github.com/lnbits/lnbits/pull/2671

Extensions that have redirect paths in conflict will fail installation.