### PR TITLE
fix: jmeter test lnurlp decoder

### DIFF
--- a/integration/002_lnurl.jmx
+++ b/integration/002_lnurl.jmx
@@ -681,7 +681,7 @@
                 </JSONPathAssertion>
                 <hashTree/>
               </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[lnurlp] Decode LNURLp" enabled="true">
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[lnurlp] Fetch LnurlPayResponse" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
                   <collectionProp name="Arguments.arguments">
@@ -698,7 +698,7 @@
                 <stringProp name="HTTPSampler.port">${port}</stringProp>
                 <stringProp name="HTTPSampler.protocol">${scheme}</stringProp>
                 <stringProp name="HTTPSampler.contentEncoding">UTF-8</stringProp>
-                <stringProp name="HTTPSampler.path">/api/v1/lnurlscan/${payLinkLnurl}</stringProp>
+                <stringProp name="HTTPSampler.path">/lnurlp/${payLinkId}</stringProp>
                 <stringProp name="HTTPSampler.method">GET</stringProp>
                 <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
                 <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/integration/002_lnurl.jmx
+++ b/integration/002_lnurl.jmx
@@ -671,15 +671,6 @@
                   <intProp name="Assertion.test_type">8</intProp>
                 </ResponseAssertion>
                 <hashTree/>
-                <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="Check lnurlp" enabled="true">
-                  <stringProp name="JSON_PATH">lnurl</stringProp>
-                  <stringProp name="EXPECTED_VALUE">${payLinkLnurl}</stringProp>
-                  <boolProp name="JSONVALIDATION">true</boolProp>
-                  <boolProp name="EXPECT_NULL">false</boolProp>
-                  <boolProp name="INVERT">false</boolProp>
-                  <boolProp name="ISREGEX">true</boolProp>
-                </JSONPathAssertion>
-                <hashTree/>
               </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="[lnurlp] Fetch LnurlPayResponse" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">false</boolProp>

--- a/integration/scripts/lnurl_extract_pay_link_id.js
+++ b/integration/scripts/lnurl_extract_pay_link_id.js
@@ -1,4 +1,3 @@
 var resp = JSON.parse(prev.getResponseDataAsString())
 
 vars.put("payLinkId", resp.id || 'no-pay-link-id');
-vars.put("payLinkLnurl", resp.lnurl || 'no-pay-link-lnurl');


### PR DESCRIPTION
fetch the lnurlpayresponse for the test directly. 
![screenshot-1755154682](https://github.com/user-attachments/assets/f80a1b8f-bad6-4ac8-961d-ed2000b52c23)
so this CI fail would have never happened. https://github.com/lnbits/lnbits/actions/runs/16937426204/job/47997430805

also i plan to remove the lnurl from the api responses here. https://github.com/lnbits/lnurlp/pull/91