### PR TITLE
Add Decoder v1.1.3 for LNbits v1.5.4+

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -130,6 +130,18 @@
             "details_link": "https://raw.githubusercontent.com/bitkarrot/decoder/main/config.json"
         },
         {
+            "id": "decoder",
+            "repo": "https://github.com/bitkarrot/decoder",
+            "name": "Decoder",
+            "min_lnbits_version": "1.5.4",
+            "version": "1.1.3",
+            "short_description": "Decode Lightning Network BOLT11, LNURL, and Lightning Address",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/decoder/main/static/unlock.png",
+            "archive": "https://github.com/bitkarrot/decoder/archive/refs/tags/v1.1.3.zip",
+            "hash": "29fb701cb3399d8924f4db7b49d1398d3a9cb9147f3611a770f1b066fee27445",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/decoder/main/config.json"
+        },
+        {
             "id": "gerty",
             "repo": "https://github.com/lnbits/gerty",
             "name": "Gerty",


### PR DESCRIPTION
## Summary
Adds the latest [Decoder extension](https://github.com/bitkarrot/decoder) release `v1.1.3` to the vetted extensions registry.

This release includes CI/CD lint fixes and dependency lock file updates that patch the majority of open Dependabot security alerts.

## Verification
- `python3 check.py decoder` passes for all decoder entries including the new `v1.1.3` entry
- Archive hash verified: `29fb701cb3399d8924f4db7b49d1398d3a9cb9147f3611a770f1b066fee27445`

Generated with [Devin](https://devin.ai)