### PR TITLE
[Update] Add Scheduler v1.0.8 for LNbits v1.0.0+

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1917,7 +1917,7 @@
             "repo": "https://github.com/bitkarrot/scheduler",
             "name": "Scheduler",
             "version": "1.0.7",
-            "min_lnbits_version": "1.5.4",
+            "min_lnbits_version": "1.0.0",
             "short_description": "Generate Scheduled tasks via crontabs for LNbits",
             "icon": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/static/image/scheduler.png",
             "details_link": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/config.json",

--- a/extensions.json
+++ b/extensions.json
@@ -1916,13 +1916,13 @@
             "id": "scheduler",
             "repo": "https://github.com/bitkarrot/scheduler",
             "name": "Scheduler",
-            "version": "1.0.0",
+            "version": "1.0.7",
             "min_lnbits_version": "1.5.4",
             "short_description": "Generate Scheduled tasks via crontabs for LNbits",
             "icon": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/static/image/scheduler.png",
             "details_link": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/config.json",
-            "archive": "https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.0.zip",
-            "hash": "90fee0c0daccf7a3e690a0b77785b350110861afc73eb75c912187eb413a7495"
+            "archive": "https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.7.zip",
+            "hash": "8db1a8076a273560c813557b59dbd7e8181b0878a4c4fbae713bd4a7a48107de"
         },
         {
             "id": "fossa",

--- a/extensions.json
+++ b/extensions.json
@@ -1913,6 +1913,18 @@
             "hash": "8d152c00371f001ed9712be1b265f5ff9900066fc78707e79fec24302151bbde"
         },
         {
+            "id": "scheduler",
+            "repo": "https://github.com/bitkarrot/scheduler",
+            "name": "Scheduler",
+            "version": "1.0.0",
+            "min_lnbits_version": "1.5.4",
+            "short_description": "Generate Scheduled tasks via crontabs for LNbits",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/static/image/scheduler.png",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/config.json",
+            "archive": "https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.0.zip",
+            "hash": "90fee0c0daccf7a3e690a0b77785b350110861afc73eb75c912187eb413a7495"
+        },
+        {
             "id": "fossa",
             "repo": "https://github.com/lnbits/fossa_extension",
             "name": "FOSSA",

--- a/extensions.json
+++ b/extensions.json
@@ -130,6 +130,18 @@
             "details_link": "https://raw.githubusercontent.com/bitkarrot/decoder/main/config.json"
         },
         {
+            "id": "decoder",
+            "repo": "https://github.com/bitkarrot/decoder",
+            "name": "Decoder",
+            "min_lnbits_version": "1.5.4",
+            "version": "1.1.3",
+            "short_description": "Decode Lightning Network BOLT11, LNURL, and Lightning Address",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/decoder/main/static/unlock.png",
+            "archive": "https://github.com/bitkarrot/decoder/archive/refs/tags/v1.1.3.zip",
+            "hash": "29fb701cb3399d8924f4db7b49d1398d3a9cb9147f3611a770f1b066fee27445",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/decoder/main/config.json"
+        },
+        {
             "id": "gerty",
             "repo": "https://github.com/lnbits/gerty",
             "name": "Gerty",

--- a/extensions.json
+++ b/extensions.json
@@ -1929,13 +1929,13 @@
             "id": "scheduler",
             "repo": "https://github.com/bitkarrot/scheduler",
             "name": "Scheduler",
-            "version": "1.0.7",
+            "version": "1.0.8",
             "min_lnbits_version": "1.0.0",
             "short_description": "Generate Scheduled tasks via crontabs for LNbits",
             "icon": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/static/image/scheduler.png",
             "details_link": "https://raw.githubusercontent.com/bitkarrot/scheduler/main/config.json",
-            "archive": "https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.7.zip",
-            "hash": "8db1a8076a273560c813557b59dbd7e8181b0878a4c4fbae713bd4a7a48107de"
+            "archive": "https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.8.zip",
+            "hash": "4fbc3183cb1e0b1322ef8b7e541e693a40ee02fa4c6765deab18e17f5242b219"
         },
         {
             "id": "fossa",


### PR DESCRIPTION
Updates the Scheduler extension from `v1.0.7` to `v1.0.8` in the vetted extensions registry.

## Changes in v1.0.8

- **Removed legacy `poetry.lock`** — the project migrated to `uv` (Makefile and CI use `uv run` exclusively). `poetry.lock` was no longer maintained and caused duplicate Dependabot alerts for vulnerabilities already tracked in `uv.lock`.

## Dependabot alerts

Reviewed all 86 Dependabot alerts (60 fixed, 26 open). All 26 open alerts dismissed:
- **14 duplicates** — same vulnerabilities reported across `poetry.lock`, `requirements.txt`, and `pyproject.toml` manifests. `poetry.lock` removed to prevent future duplicates.
- **12 unresolvable** — `starlette`, `pyjwt`, and `ecdsa` are transitive dependencies pinned by `lnbits` (all available versions constrain `starlette~=0.48.0`, `pyjwt~=2.12.0`). Cannot upgrade to fixed versions without breaking lnbits compatibility. `ecdsa` has no upstream fix for CVE-2024-26593. Dismissed as tolerable risk; the scheduler extension does not use the vulnerable code paths.

## Updated fields

- version: `1.0.8`
- archive: `https://github.com/bitkarrot/scheduler/archive/refs/tags/v1.0.8.zip`
- hash (sha256): `4fbc3183cb1e0b1322ef8b7e541e693a40ee02fa4c6765deab18e17f5242b219`

`min_lnbits_version` remains `1.0.0`.