### PR TITLE
Add Income Report extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -29,6 +29,16 @@
     },
     "extensions": [
         {
+            "id": "incomereport",
+            "repo": "https://github.com/lightning-goats/incomereport_extension",
+            "name": "Income Report",
+            "version": "0.1.0",
+            "short_description": "Accounting reports: daily, weekly, monthly and yearly income per wallet with fiat values and CSV export",
+            "icon": "https://raw.githubusercontent.com/lightning-goats/incomereport_extension/main/static/image/incomereport.png",
+            "archive": "https://github.com/lightning-goats/incomereport_extension/archive/refs/tags/v0.1.0.zip",
+            "hash": "3ea2440dc2b5f36254ef46884876204b44aae18ecde14eb0cef01c9a2e6f212b"
+        },
+        {
             "id": "copilot",
             "repo": "https://github.com/lnbits/copilot",
             "name": "Streamer Copilot",


### PR DESCRIPTION
Adds the **Income Report** extension to the vetted registry.

- **Repo:** https://github.com/lightning-goats/incomereport_extension
- **Release:** [v0.1.0](https://github.com/lightning-goats/incomereport_extension/releases/tag/v0.1.0)
- **What it does:** Accounting-oriented income reporting over the core `apipayments` read model — daily / weekly / monthly / yearly income per wallet, fiat values recorded at payment time, bar + cumulative charts, and CSV export (both aggregated summary and a transaction-level ledger). User-scoped: each user sees only their own wallets.

### Checklist
- ✅ **No new dependencies** — uses only what LNbits already ships (FastAPI, Quasar, the bundled Chart.js v4).
- ✅ **Fully working** — pure read model: no own tables/migrations, no background tasks, no invoice listener.
- ✅ `id` `incomereport` is unique in the registry.
- ✅ Icon is a PNG served from `main`; the `hash` matches the tagged source archive.
