### PR TITLE
Add Nsec Oracle extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -29,6 +29,16 @@
     },
     "extensions": [
         {
+            "id": "nsec_oracle",
+            "repo": "https://github.com/lightning-goats/nsec_oracle",
+            "name": "Nsec Oracle",
+            "version": "1.0.0",
+            "short_description": "Server-side Nostr signing oracle for LNbits extensions (per-key permissions, rate limits, audit)",
+            "icon": "https://raw.githubusercontent.com/lightning-goats/nsec_oracle/main/static/image/nsec_oracle.png",
+            "archive": "https://github.com/lightning-goats/nsec_oracle/archive/refs/tags/v1.0.0.zip",
+            "hash": "832cff09e963d3f38b2149a1f3bc058b9ba36be9b02c95866c52ff2c2815c818"
+        },
+        {
             "id": "copilot",
             "repo": "https://github.com/lnbits/copilot",
             "name": "Streamer Copilot",


### PR DESCRIPTION
Adds **Nsec Oracle** to the vetted registry.

- **Repo:** https://github.com/lightning-goats/nsec_oracle
- **Release:** [v1.0.0](https://github.com/lightning-goats/nsec_oracle/releases/tag/v1.0.0)

### What it is
An **in-instance Nostr signing oracle** for LNbits: it holds Nostr keys server-side (encrypted at rest with the instance secret) and lets *other installed extensions* — and admin-key API clients — sign events and encrypt/decrypt through per-key, per-kind permissions with rate limits and an audit log, **without the key ever leaving the oracle**. It also auto-discovers extensions that declare `nostr_signing` requirements.

### How it differs from `nostr_bunker`
This is deliberately **not** a relay-facing remote signer. `lnbits/nostr_bunker` serves *external* Nostr apps over `bunker://` / `nostrconnect://`; Nsec Oracle serves *in-instance* consumers (extensions + local API). They're complementary, not overlapping — the extension explicitly points external users to `nostr_bunker`.

### Checklist
- ✅ **No new dependencies** — uses only what LNbits already ships (FastAPI, `pynostr`, `nostr_sdk`).
- ✅ **Fully working** — encrypted key vault, permissions, rate limits, NIP-04/44, discovery, audit log; 21 tests passing.
- ✅ `id` `nsec_oracle` is unique in the registry.
- ✅ Icon is a PNG served from `main`; the `hash` matches the tagged source archive.
