### PR TITLE
Introducing the laisee extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -250,6 +250,16 @@
             "archive": "https://github.com/lnbits/jukebox/archive/refs/tags/v1.0.4.zip",
             "hash": "28f5d7e2d1127bb3e3d37ecb721a13e077ddadcc00cffdd0e5334291097e34ee"
         },
+         {
+            "id": "laisee",
+            "repo": "https://github.com/liongrass/laisee_extension",
+            "name": "Laisee",
+            "version": "0.7",
+            "short_description": "Little red envelopes with money: Lightning Laisee.",
+            "icon": "https://raw.githubusercontent.com/Liongrass/laisee_extension/a8206fe479f7d4075f2e53b09ecb047169b1a834/assets/icon.png",
+            "archive": "https://github.com/Liongrass/laisee_extension/archive/refs/tags/v0.7.zip",
+            "hash": "6457798f6a90b96fd1306faf896b92aa66671548aaa9de1d3e87fad988b97367"
+        },
         {
             "id": "lnticket",
             "repo": "https://github.com/lnbits/lnticket",


### PR DESCRIPTION
In this pull request, I'm introducing the 🧧Laisee extension and request for it to be added to the repository.

A Laisee is a special kind of LNURL. When created, it acts as an LNURLp and can be loaded with money. Once loaded, it acts as an LNURLw and can be redeemed. After a Laisee has been redeemed, the LNURL can no longer be used and is to be discarded.

The main use case of 🧧Laisee is gifts and tipping. The user pre-prints Laisee and configures a minimum and maximum amount they can hold. They can also let the funder add a message as a comment.

The gifter then funds them spontaneously from their own wallet when they want to give away sats. At that point, they can dynamically choose which amount they want to gift, and attach a personal message.

That personal message is then viewable by the recipient, who is able to withdraw the amount at any time to their own wallet. Once they do so, they can throw away their Laisee.