### PR TITLE
Add bulk giftcards extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -2335,6 +2335,18 @@
             "short_description": "A reusable merchant ledger for open balances",
             "icon": "https://raw.githubusercontent.com/lnbits/tabs/main/static/image/tabs.png",
             "details_link": "https://raw.githubusercontent.com/lnbits/tabs/main/config.json"
+        },
+        {
+            "id": "giftcards",
+            "repo": "https://github.com/bitkarrot/giftcards",
+            "name": "Gift Cards",
+            "version": "0.2.1",
+            "min_lnbits_version": "1.5.4",
+            "short_description": "Create and redeem sats-denominated gift cards with unique secure links",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/static/image/giftcards.png",
+            "archive": "https://github.com/bitkarrot/giftcards/archive/refs/tags/v0.2.1.zip",
+            "hash": "aab0eb858a7a418ceab1eb68076d4707dbcf3b2ece2b6c3a440d55deff379a4f",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/config.json"
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds the **Gift Cards** extension (bitkarrot/giftcards) to the registry.
- Allows users to create custom bulk gift cards of any kind and any type
- Enables magic link email to claim giftcards using built in SMTP in LNbits
- Create and redeem sats-denominated gift cards with unique secure links.

### Extension details

| Field | Value |
| --- | --- |
| id | giftcards |
| repo | https://github.com/bitkarrot/giftcards |
| version | 0.2.1 |
| min_lnbits_version | 1.5.4 |
| license | MIT |

A LICENSE file was added to the giftcards repo and the version bumped to 0.2.1 so the release archive satisfies the registry's mandatory-file checks.

#### Verification

- [x] extensions.json is valid JSON
- [x] check.py giftcards passes (archive hash matches, icon resolves, min_lnbits_version matches config.json, all mandatory files present in the archive)
