### PR TITLE
Add Bulk giftcards extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -2335,6 +2335,18 @@
             "short_description": "A reusable merchant ledger for open balances",
             "icon": "https://raw.githubusercontent.com/lnbits/tabs/main/static/image/tabs.png",
             "details_link": "https://raw.githubusercontent.com/lnbits/tabs/main/config.json"
+        },
+        {
+            "id": "giftcards",
+            "repo": "https://github.com/bitkarrot/giftcards",
+            "name": "Gift Cards",
+            "version": "0.2.1",
+            "min_lnbits_version": "1.5.4",
+            "short_description": "Create and redeem sats-denominated gift cards with unique secure links",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/static/image/giftcards.png",
+            "archive": "https://github.com/bitkarrot/giftcards/archive/refs/tags/v0.2.1.zip",
+            "hash": "aab0eb858a7a418ceab1eb68076d4707dbcf3b2ece2b6c3a440d55deff379a4f",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/config.json"
         }
     ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -2340,12 +2340,12 @@
             "id": "giftcards",
             "repo": "https://github.com/bitkarrot/giftcards",
             "name": "Gift Cards",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "min_lnbits_version": "1.5.4",
             "short_description": "Create and redeem sats-denominated gift cards with unique secure links",
             "icon": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/static/image/giftcards.png",
-            "archive": "https://github.com/bitkarrot/giftcards/archive/refs/tags/v0.2.1.zip",
-            "hash": "aab0eb858a7a418ceab1eb68076d4707dbcf3b2ece2b6c3a440d55deff379a4f",
+            "archive": "https://github.com/bitkarrot/giftcards/archive/refs/tags/v0.2.2.zip",
+            "hash": "dd307559ab45f09685db064efd5c6eb900a25fa51ed1c19811123facd6e47a97",
             "details_link": "https://raw.githubusercontent.com/bitkarrot/giftcards/main/config.json"
         }
     ]


### PR DESCRIPTION
## Summary

- Adds the Gift Cards extension (bitkarrot/giftcards) to the registry.
- Create and redeem sats-denominated gift cards with unique secure links.
- **FUTURE PLAN:** to make extension handle LNURLCash (not this version, but next one)

### Features

- Single & bulk creation — Create one card or hundreds via CSV upload
- Custom card design — Drag-and-drop QR/text placement, font controls, color pickers, portrait/landscape templates, or upload your own template image
- Secure redemption — Each card gets a unique, unguessable token and shareable link; recipients redeem by scanning a QR code with any Lightning wallet
- Email delivery — Send branded gift card images directly to recipients via email
- Printable PNG — Download high-resolution (3x) card images for manual distribution
- Expiration & auto-refund — Set expiration dates; unclaimed sats are automatically returned to the issuer wallet
- Issuer dashboard — Filter, search, and manage all cards with bulk actions (email, CSV export, delete)

### Extension details

| Field | Value |
| --- | --- |
| id | giftcards |
| repo | https://github.com/bitkarrot/giftcards |
| version | 0.2.2 |
| min_lnbits_version | 1.5.4 |
| license | MIT |

A LICENSE file was added to the giftcards repo and the version bumped to 0.2.1 so the release archive satisfies the registry's mandatory-file checks. v0.2.2 additionally fixes an install failure caused by importing `run_interval` from `lnbits.tasks` (not available on LNbits dev); the extension now uses the standard asyncio periodic loop pattern.

#### Verification

- [x] extensions.json is valid JSON
- [x] check.py giftcards passes (archive hash matches, icon resolves, min_lnbits_version matches config.json, all mandatory files present in the archive)
- [x] jmeter CI passes (extension installs, enables, and serves GET /giftcards/ 200)
