### PR TITLE
Add lnurlmint v0.1.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,7 +75,7 @@ jobs:
             AUTH_HTTPS_ONLY: false
             AUTH_ALLOWED_METHODS: "user-id-only, username-password"
             LNBITS_EXTENSIONS_DEFAULT_INSTALL: "watchonly, satspay, tipjar, tpos, lnurlp, withdraw"
-            LNBITS_EXTENSIONS_MANIFESTS: "https://raw.githubusercontent.com/lnbits/lnbits-extensions/${{ github.head_ref || github.ref_name }}/extensions.json"
+            LNBITS_EXTENSIONS_MANIFESTS: "https://raw.githubusercontent.com/${{ github.event.pull_request.head.repo.full_name || github.repository }}/${{ github.event.pull_request.head.ref || github.ref_name }}/extensions.json"
             LNBITS_BACKEND_WALLET_CLASS: FakeWallet
           run: |
             git clone https://github.com/lnbits/lnbits.git

--- a/extensions.json
+++ b/extensions.json
@@ -2340,13 +2340,13 @@
             "id": "lnurlmint",
             "repo": "https://github.com/bitkarrot/lnurlmint",
             "name": "Lnurlmint",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "min_lnbits_version": "1.5.4",
             "short_description": "Mint Lightning-funded bearer notes (LUD-25 lnurlcash)",
             "icon": "https://raw.githubusercontent.com/bitkarrot/lnurlmint/main/static/image/lnurlmint.png",
             "details_link": "https://raw.githubusercontent.com/bitkarrot/lnurlmint/main/config.json",
-            "archive": "https://github.com/bitkarrot/lnurlmint/archive/refs/tags/v0.1.2.zip",
-            "hash": "e55e482b255e7aa5e15036dac9afc3b7249d7fe00208525adb8d3fd1edb27d27"
+            "archive": "https://github.com/bitkarrot/lnurlmint/archive/refs/tags/v0.1.3.zip",
+            "hash": "847cbc37767de1f4dfd1d5d41fc7426c4cc1e805c9c337209337da481027ec6c"
         }
     ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -2335,6 +2335,18 @@
             "short_description": "A reusable merchant ledger for open balances",
             "icon": "https://raw.githubusercontent.com/lnbits/tabs/main/static/image/tabs.png",
             "details_link": "https://raw.githubusercontent.com/lnbits/tabs/main/config.json"
+        },
+        {
+            "id": "lnurlmint",
+            "repo": "https://github.com/bitkarrot/lnurlmint",
+            "name": "Lnurlmint",
+            "version": "0.1.2",
+            "min_lnbits_version": "1.5.4",
+            "short_description": "Mint Lightning-funded bearer notes (LUD-25 lnurlcash)",
+            "icon": "https://raw.githubusercontent.com/bitkarrot/lnurlmint/main/static/image/lnurlmint.png",
+            "details_link": "https://raw.githubusercontent.com/bitkarrot/lnurlmint/main/config.json",
+            "archive": "https://github.com/bitkarrot/lnurlmint/archive/refs/tags/v0.1.2.zip",
+            "hash": "e55e482b255e7aa5e15036dac9afc3b7249d7fe00208525adb8d3fd1edb27d27"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds [lnurlmint](https://github.com/bitkarrot/lnurlmint) v0.1.2 to the vetted extensions registry.

lnurlmint implements [LUD-25 lnurlcash](https://github.com/lnurlw/LUDs/blob/luds/25.md), letting each LNbits wallet run its own mint of Lightning-funded bearer notes. Notes circulate offline as `lnurlw://` withdraw links and can be rotated, split, merged, or melted back into a BOLT-11 payment. A port of the standalone [`lnurl-mint`](https://github.com/dni/lnurl-mint) FastAPI app into the LNbits extension model.

### Features
- Per-wallet mints with custom fees, limits, and identity
- Mint (LUD-06), Melt (LUD-03), Rotate, Split, Merge
- Verify (LUD-21) settlement status + offline verification (LUD-25) secp256k1 signatures
- Comment-protected notes, sunset mode, Tor support
- Management SPA + public one-pager with QR/LNURL/node info

### Manifest
- `id`: lnurlmint
- `version`: 0.1.2
- `min_lnbits_version`: 1.5.4
- `archive`: https://github.com/bitkarrot/lnurlmint/archive/refs/tags/v0.1.2.zip
- `hash`: `e55e482b255e7aa5e15036dac9afc3b7249d7fe00208525adb8d3fd1edb27d27`

### Verification
- [x] `python3 check.py lnurlmint` passes (hash match, icon OK, min_lnbits_version match)
- [x] Archive excludes `tests/`, `.planning/`, `.claude/` via `.gitattributes` `export-ignore`
- [x] Archive contains mandatory files: `LICENSE`, `README.md`, `__init__.py`, `config.json`, `manifest.json`
- [x] `details_link` points to the repo `config.json`

#### Test plan
- [ ] `python3 check.py lnurlmint` from a clean checkout of this PR